### PR TITLE
Fix AttributeError: 'list' object has no attribute 'mols'

### DIFF
--- a/gypsum_dl/Steps/SMILES/DurrantLabFilter.py
+++ b/gypsum_dl/Steps/SMILES/DurrantLabFilter.py
@@ -117,7 +117,7 @@ def durrant_lab_filters(contnrs, num_procs, job_manager, parallelizer_obj):
     if parallelizer_obj is None:
         tmp.extend(
             parallel_durrant_lab_filter(c, prohibited_substructs)
-            for c in params
+            for c, prohibited_substructs in params
         )
     else:
         tmp = parallelizer_obj.run(


### PR DESCRIPTION
# Changelogs

- Fixes a bug that causes AttributeError: 'list' object has no attribute 'mols' in the `durrant_lab_filter` function. This error occurs when --use_durrant_lab_filters is enabled in mpi mode.
  Related issues:
  - https://durrantlab.pitt.edu/forums/topic/durrant-filters-cause-python-error/
  - https://durrantlab.pitt.edu/forums/topic/issue-with-durrantlabfilter-in-parallel-jobs/

  Even if the same commands are used to install and run the program, whether the error occurs or not seems to depend on the environment; in my case, the error did not occur on my local machine, but it did occur when I ran the same procedure in a Docker container (condaforge/miniforge3:23.3.1-1).

  Here are the commands to reproduce the error in a condaforge/miniforge3:23.3.1-1 Docker container:

  ```bash
  # Install dependencies
  apt-get update && apt-get install -y openmpi-bin
  conda install -y -c conda-forge rdkit=2023.03.3 numpy=1.26.0 scipy=1.11.3 mpi4py=3.1.4

  # Download gypsum_dl (v1.2.1) and run the program in mpi mode
  git clone -b 1.2.1 --depth 1 https://github.com/durrantlab/gypsum_dl.git && cd gypsum_dl

  # OK
  mpirun -n 2 python -m mpi4py run_gypsum_dl.py --source ./examples/sample_molecules.smi --job_manager mpi

  # AttributeError: 'list' object has no attribute 'mols'
  mpirun -n 2 python -m mpi4py run_gypsum_dl.py --source ./examples/sample_molecules.smi --job_manager mpi --use_durrant_lab_filters
  ```

  This error seems to be caused by a small bug and this PR simply fixes it:

  ```python
  # Get the parameters to pass to the parallelizer object.
  params = [[c, prohibited_substructs] for c in contnrs]

  # Run the tautomizer through the parallel object.
  tmp = []
  if parallelizer_obj is None:
      tmp.extend(
          parallel_durrant_lab_filter(c, prohibited_substructs)
          for c in params  # BUG: params is a list of lists [c, prohibited_substructs], not a list of container objects.
      )
  else:
      tmp = parallelizer_obj.run(
          params, parallel_durrant_lab_filter, num_procs, job_manager
      )
  ```

I have confirmed that the change in this PR fixes my problem. Could you please check if this fix is correct?

Thanks.